### PR TITLE
Encode translated messages to utf8 to avoid perl warnings

### DIFF
--- a/lib/App/enman.pm
+++ b/lib/App/enman.pm
@@ -36,11 +36,11 @@ sub error {
         print STDERR color 'bold red';
         print STDERR encode_utf8('☢☢☢ ☛    ');
         print STDERR color 'bold magenta';
-        print STDERR join( "\n", @msg ), "\n";
+        print STDERR encode_utf8(join( "\n", @msg )), "\n";
         print STDERR color 'reset';
     }
     elsif ( $self->{LOG_LEVEL} eq "quiet" ) {
-        print join( "\n", @msg ), "\n";
+        print encode_utf8(join( "\n", @msg )), "\n";
     }
 }
 
@@ -56,11 +56,11 @@ sub info {
         print color 'bold green';
         print encode_utf8('╠   ');
         print color 'bold blue';
-        print join( "\n", @msg ), "\n";
+        print encode_utf8(join( "\n", @msg )), "\n";
         print color 'reset';
     }
     elsif ( $self->{LOG_LEVEL} eq "quiet" ) {
-        print join( "\n", @msg ), "\n";
+        print encode_utf8(join( "\n", @msg )), "\n";
     }
 }
 
@@ -71,11 +71,11 @@ sub notice {
         print STDERR color 'bold yellow';
         print STDERR encode_utf8('☛   ');
         print STDERR color 'bold green';
-        print STDERR join( "\n", @msg ), "\n";
+        print STDERR encode_utf8(join( "\n", @msg )), "\n";
         print STDERR color 'reset';
     }
     elsif ( $self->{LOG_LEVEL} eq "quiet" ) {
-        print STDERR join( "\n", @msg ), "\n";
+        print STDERR encode_utf8(join( "\n", @msg )), "\n";
     }
 }
 

--- a/lib/App/enman/Command/list.pm
+++ b/lib/App/enman/Command/list.pm
@@ -4,6 +4,7 @@ use App::enman -command;
 use App::enman::Command::search;
 use Locale::TextDomain 'App-enman';
 use App::enman;
+use Encode;
 sub abstract { "List repositories installed in the system" }
 
 sub description {
@@ -39,7 +40,7 @@ sub execute {
     }
     else {
         $self->usage_error(
-            __("You should at least supply --installed or --available") );
+            encode_utf8(__("You should at least supply --installed or --available")) );
     }
 }
 


### PR DESCRIPTION
When enman shows translated messages a perl warning appears that breaks output. Eg.

$ enman add
☢☢☢ ☛    Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 39.
Πρέπει να δώσετε όνομα αποθετηρίου

$ enman list -A
╠   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 59.
Εμφάνιση όλων των αποθετηρίων που είναι διαθέσιμα εξ αποστάσεως
☛   ======
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: community - "community Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: sihnon-desktop - "sihnon-desktop Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: sihnon-common - "sihnon-common Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: sihnon-server - "sihnon-server Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: gaming-live - "gaming-live Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: mudler - "mudler Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: devel - "devel channel repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: pentesting - "Pentesting Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: gnome-unstable - "gnome-unstable Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: kdepim - "kdepim Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: kde-unstable - "kde-unstable Repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: tlp - "None found"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: haskell - "Haskell repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: elementary - "Elementary repository"
☛   Wide character in print at /usr/lib64/perl5/vendor_perl/5.24.1/App/enman.pm line 74.
Αποθετήριο: ruby - "Ruby packages (unstable)"

Using the PR the msg is converted using encode_utf8 to avoid such warnings. po files appear to be encoded in utf8 so it should work for all languages.